### PR TITLE
Update COC 

### DIFF
--- a/COC.md
+++ b/COC.md
@@ -45,21 +45,7 @@ When users create a channel they are designated as the moderator for that channe
 ----
 
 ## Message limit and archives
-The Spatial Community is currently on the free Slack tier with no plan to move to a paid team. This means that we are limited to 10,000 messages total, with private messages included in that count. <del>As such, we have deployed a service via @archivebot, a ‘Public chat archive for your Slack community’, to help maintain the history of various channels. When @archivebot is added to a channel the message thread is automatically replicated at [http://gisdevs.slackarchive.io/](http://gisdevs.slackarchive.io/). If you feel that @archivebot should archive a channel, feel free to ask the moderator of your channel to invite them.  An example of the following channels currently have @archivebot as a member are are being publicly archived:</del>
-
-* ~~#algorithms~~
-* ~~#announcements~~
-* ~~#arcgis~~
-* ~~#cartography-designs~~
-* ~~#general~~
-* ~~#leafletjs~~
-* ~~#mapbox~~
-* ~~#n00bs~~
-* ~~#openstreetmap~~
-* ~~#remote-sensing~~
-* ~~#startups~~
-
-<del>Channel moderators can add @archivebot using /invite @archivebot or remove it by using /kick @archivebot.  Any edits after the initial message has posted to the channel will not be included.  Any messages deleted after the initial message has posted will still reside in the archive and the deletion will not be reflected.</del>
+The Spatial Community is currently on the free Slack tier with no plan to move to a paid team. This means that we are limited to 10,000 messages total, with private messages included in that count. Message archives are **not** retained, by either the admins, Slack team owners, or any third-party service.
 
 ----
 

--- a/COC.md
+++ b/COC.md
@@ -1,9 +1,9 @@
 # The Spatial Community - Code of Conduct
 
 The Spatial Community
-Date Posted: 7/26/2016, Last Updated: 8/08/2016
+Date Posted: 7/26/2016, Last Updated: 1/26/2017
 
-_Version 1.05_
+_Version 1.06_
 
 ## Creating a Culture of Innovation
 We aspire to create a culture where people work joyfully, communicate openly about things that matter, and collaborate on projects. We would like our community to reflect the diversity of the wider community of geospatial and IT professionals. We want to foster diversity of all kinds—not just the classes protected in law. Diversity fosters innovation. Diverse teams are creative teams. We need a diversity of perspective to create solutions for the real and urgent challenges we face.

--- a/COC.md
+++ b/COC.md
@@ -68,7 +68,12 @@ If you are unsure if something is appropriate behavior, it probably isn’t. Eac
 ----
 
 ## Reporting
-This Code of Conduct is a work in progress. A formal reporting process has not yet been established. In the meantime, if you are being harassed in The Spatial Community, please speak to the community organizer, owner, or admin. Admins are required to include full contact details in their profile so that you may reach them in multiple ways.
+
+If you are being harassed, or witness any violation of this Code of Conduct, please let an admin know.
+
+To get in touch with the admin team, you can send a Direct Message within Slack to any/all of the Current Admins (listed below). You can also use the slack command `/call_admin <optional message here>` from any channel to send an immediate notification to the entire admin team. This command is private (visible to only you and the admin team).
+
+Outside of slack, you can email thespatialcommunity@gmail.com; individual admin contact information is also listed below. 
 
 ### Current Admins:
 * **Julien Jacques** (owner)

--- a/COC.md
+++ b/COC.md
@@ -76,29 +76,11 @@ To get in touch with the admin team, you can send a Direct Message within Slack 
 Outside of slack, you can email thespatialcommunity@gmail.com; individual admin contact information is also listed below. 
 
 ### Current Admins:
-* **Julien Jacques** (owner)
-    * Slack: @julien
-    * Twitter: [@julienjacques](https://twitter.com/julienjacques)
-    * GitHub: [juljacques](https://github.com/juljacques)
-    * Email: julien@maptiks.com
-    * Cell: 604-339-9424
-* **Will Caddell** (admin)
-    * Slack: @willcadell
-    * Twitter: [@geo_will](https://twitter.com/geo_will)
-    * GitHub: [willcadell](https://github.com/willcadell)
-    * Email: will@sparkgeo.com
-    * Cell: 250-981-69646
 * **Daniel Smith** (admin)
     * Slack: @robodonut
     * Twitter: [@robodonut](https://twitter.com/robodonut)
     * GitHub: [robodonut](https://github.com/robodonut)
     * Email: danielelijahsmith@gmail.com
-* **Stephen Smith** (admin)
-    * Slack: @themapsmith
-    * Twitter: [@TheMapSmith](https://twitter.com/TheMapSmith)
-    * GitHub: [TheMapSmith](https://github.com/themapsmith)
-    * Email: stephen@mapsmith.net
-    * Cell: 512-587-8671
 * **Kyle Morgan** (admin)
     * Slack: @gisdev-km
     * Twitter: [@gisdev_km](https://twitter.com/gisdev_km)

--- a/COC.md
+++ b/COC.md
@@ -6,9 +6,9 @@ Date Posted: 7/26/2016, Last Updated: 1/26/2017
 _Version 1.06_
 
 ## Creating a Culture of Innovation
-We aspire to create a culture where people work joyfully, communicate openly about things that matter, and collaborate on projects. We would like our community to reflect the diversity of the wider community of geospatial and IT professionals. We want to foster diversity of all kinds—not just the classes protected in law. Diversity fosters innovation. Diverse teams are creative teams. We need a diversity of perspective to create solutions for the real and urgent challenges we face.
+We aspire to create a culture where people work joyfully, communicate openly about things that matter, and collaborate on projects. We would like our community to reflect the diversity of the wider community of geospatial and IT professionals. We want to foster diversity of all kinds-not just the classes protected in law. Diversity fosters innovation. Diverse teams are creative teams. We need a diversity of perspective to create solutions for the real and urgent challenges we face.
 
-This is the Spatial Community’s Code of Conduct. We expect everyone we work with to adhere to the [GSA Anti-harassment Policy](http://www.gsa.gov/portal/directive/d0/content/512516). Even though most community members and participants will not be employed by the General Services Administration, we feel this to be an exemplar of anti-harassment policy.
+This is the Spatial Community's Code of Conduct. We expect everyone we work with to adhere to the [GSA Anti-harassment Policy](http://www.gsa.gov/portal/directive/d0/content/512516). Even though most community members and participants will not be employed by the General Services Administration, we feel this to be an exemplar of anti-harassment policy.
 
 We expect everyone who joins our Slack channel to follow this code of conduct and the laws and policies mentioned above. This applies to all of our methods of communication: the #general and #random channels, all topical channels, uploaded files, and private messages.
 
@@ -37,10 +37,10 @@ The Spatial Community is a different kind of place. There is a mix of hobbyists 
 
 ## New channel creation
 
-We want to support the wide range of topics people might want to come here to discuss, but it’s hard to balance that support with making The Spatial Community approachable. New channels can be created by anybody, but should generally only be created when a critical mass exists around a topic. Some short term topics like #esriuc_backchannel or #foss4g may warrant a temporary channel and will be created while timely and then retired.
+We want to support the wide range of topics people might want to come here to discuss, but it's hard to balance that support with making The Spatial Community approachable. New channels can be created by anybody, but should generally only be created when a critical mass exists around a topic. Some short term topics like #esriuc_backchannel or #foss4g may warrant a temporary channel and will be created while timely and then retired.
 
 Over time, if a channel becomes quiet, the admins may archive the channel.
-When users create a channel they are designated as the moderator for that channel. As such, they are responsible for the channel and ensuring that it meets the guidelines put forth in this document. Should channel moderators have issues, they are encouraged to contact the Admin team, see Reporting below.
+When users create a channel they are designated as the moderator for that channel. As such, they are responsible for the channel and ensuring that it meets the guidelines put forth in this document. Should channel moderators have issues, they are encouraged to contact the Admin team, see **Reporting** below.
 
 ----
 
@@ -53,7 +53,7 @@ The Spatial Community is currently on the free Slack tier with no plan to move t
 
 Create boundaries to your own behavior and consider how you can create safe space that helps prevent unacceptable behavior by others. We do not seek to list all cases of unacceptable behavior, but provide examples to help guide our community in thinking through how to respond when we experience these types of behavior, whether directed at ourselves or others.
 
-If you are unsure if something is appropriate behavior, it probably isn’t. Each person you interact with can define where that line is for them. Impact matters more than intent. Ensuring that your behavior does not have a negative impact is your responsibility. Problems happen when we assume that our way of thinking or behaving is the norm or ok with everyone. This is particularly problematic when we are in a position of power or privilege.
+If you are unsure if something is appropriate behavior, it probably isn't. Each person you interact with can define where that line is for them. Impact matters more than intent. Ensuring that your behavior does not have a negative impact is your responsibility. Problems happen when we assume that our way of thinking or behaving is the norm or ok with everyone. This is particularly problematic when we are in a position of power or privilege.
 
 ### Here are a few examples of unacceptable behavior:
 
@@ -61,7 +61,7 @@ If you are unsure if something is appropriate behavior, it probably isn’t. Eac
 * Touching people without their affirmative consent.
 * Sustained and negative disruption of meetings or talks.
 * Patronizing language or behavior.
-* Aggressive and micro-aggressive behavior, such as unconstructive criticism, providing corrections that do not improve the conversation (sometimes referred to as "well actually"s), repeatedly interrupting or talking over someone else, feigning surprise at someone’s lack of knowledge or awareness about a topic, or subtle prejudice (for example, comments like “That’s so easy my grandmother could do it.”).
+* Aggressive and micro-aggressive behavior, such as unconstructive criticism, providing corrections that do not improve the conversation (sometimes referred to as "well actually"s), repeatedly interrupting or talking over someone else, feigning surprise at someone's lack of knowledge or awareness about a topic, or subtle prejudice (for example, comments like "That's so easy my grandmother could do it.").
 * Referring to people in a way that misidentifies their gender and/or rejects the validity of their gender identity; for instance by using incorrect pronouns or forms of address (misgendering).
 * Retaliating against anyone who files a formal complaint that someone has violated these codes or laws.
 

--- a/COC.md
+++ b/COC.md
@@ -24,7 +24,7 @@ Consider what you can do to encourage and support others. Make room for quieter 
 The Spatial Community is a different kind of place. There is a mix of hobbyists and professionals, newbies and pros, lurkers and sharers, vendors and consumers. To keep the environment open and honest, please adhere to the following guidelines:
 
 ### Hard and fast rules
-* If you are affiliated with a company, be sure to include that in your profile in the “What I Do” section.
+* If you are affiliated with a company, and will be posting primarily as a representative of said company, be sure to include that in your profile in the "What I Do" section.
 * The broadcast messages @channel, @here, @group, or @everyone are intended for important issues only and should be used sparingly. To know the difference, please read more [here](https://get.slack.help/hc/en-us/articles/202009646-Making-announcements).
 * Regarding commercial promotion of yourself or your company, this is not a marketing forum or a source for new customers. Feel free to share your projects and events but refrain from using it from a sole marketing purpose.  The admins reserve the right to moderate your posts if it is abused.
 * The Admin team will not use your email address for marketing or promotion. Occasional community-related messages may be sent to inform you of events or other important matters. Your email will not be sold to or used by 3rd parties. Please note that your e-mail address is viewable by other members when they view your profile.


### PR DESCRIPTION
Adding in `/call_admin` slack command to clarify our Reporting guidelines -- also removing retired admin contact info.